### PR TITLE
Fix README filename in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,10 @@ FROM install AS publish
 
 WORKDIR /app
 RUN echo '' > ./requirements.txt
-COPY app.py LICENSE README.md ./
+# Use the correct casing for the project README file. Linux filesystems are
+# case-sensitive, so the previous instruction looked for `README.md` which
+# does not exist, causing the Docker build to fail.
+COPY app.py LICENSE Readme.md ./
 COPY interface ./interface
 COPY modules ./modules
 


### PR DESCRIPTION
## Summary
- use correct casing for README file in Dockerfile so build can locate it

## Testing
- `pytest`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891dda587c4832d80bfaef2c2d05ea1