### PR TITLE
Accept Anaconda ToS during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,10 @@ RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.s
 
 ENV PATH=/opt/conda/bin:$PATH
 
-RUN conda create --name karaoke_env python=3.10 -y && conda init bash
+RUN conda tos accept --yes --channel https://repo.anaconda.com/pkgs/main && \
+    conda tos accept --yes --channel https://repo.anaconda.com/pkgs/r && \
+    conda create --name karaoke_env python=3.10 -y && \
+    conda init bash
 
 FROM base AS download
 


### PR DESCRIPTION
## Summary
- accept Anaconda default channel terms prior to creating the `karaoke_env` conda environment to allow non-interactive builds

## Testing
- `docker build --target base -t karaoke-test-base .` *(fails: `docker: command not found`)*
- `python -m py_compile app.py run.py run_timing_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_6891e0270a48832da0dba452a9f62086